### PR TITLE
Don't force openapiFile to be relative to script source directory.

### DIFF
--- a/src/app.mstr-acct.spec.ts
+++ b/src/app.mstr-acct.spec.ts
@@ -4,7 +4,7 @@ import { ValidateFiles } from './app.spec';
 import { IGeneratorOptions } from './models/generator-options';
 
 const accountGenerationOptionsFactory = (): IGeneratorOptions => ({
-  openApiJsonFileName: './open-api-spec-docs/mstr-acct.json',
+  openApiJsonFileName: `${__dirname}/open-api-spec-docs/mstr-acct.json`,
   outputPath: './jest_output/acct/',
   typeFilterCallBack: nrsrxTypeFilterCallBack,
   valuePropertyTypeFilterCallBack: nrsrxValuePropertyTypeFilterCallBack,

--- a/src/app.mstr-msg.spec.ts
+++ b/src/app.mstr-msg.spec.ts
@@ -5,7 +5,7 @@ import { IGeneratorOptions } from './models/generator-options';
 import { IEntity } from './models/template-data';
 
 const messageGenerationOptionsFactory = (): IGeneratorOptions => ({
-  openApiJsonFileName: './open-api-spec-docs/mstr-msg.json',
+  openApiJsonFileName: `${__dirname}/open-api-spec-docs/mstr-msg.json`,
   outputPath: './jest_output/msng/',
   typeFilterCallBack: (val: IEntity, i: number, arr: IEntity[]) =>
     nrsrxTypeFilterCallBack(val, i, arr) && val.name !== 'GetMessageInfoResponse',

--- a/src/app.mstr-unit.spec.ts
+++ b/src/app.mstr-unit.spec.ts
@@ -5,7 +5,7 @@ import { IGeneratorOptions } from './models/generator-options';
 import { MockConsoleLogger } from './models/logger';
 
 const unitGenerationOptionsFactory = (): IGeneratorOptions => ({
-  openApiJsonFileName: './open-api-spec-docs/mstr-unit.json',
+  openApiJsonFileName: `${__dirname}/open-api-spec-docs/mstr-unit.json`,
   outputPath: './jest_output/unit/',
   typeFilterCallBack: nrsrxTypeFilterCallBack,
   valuePropertyTypeFilterCallBack: nrsrxValuePropertyTypeFilterCallBack,

--- a/src/app.nrcr-empl.spec.ts
+++ b/src/app.nrcr-empl.spec.ts
@@ -4,7 +4,7 @@ import { ValidateFiles } from './app.spec';
 import { IGeneratorOptions } from './models/generator-options';
 
 const fileEmployeeGenerationOptionsFactory = (): IGeneratorOptions => ({
-  openApiJsonFileName: '../src/open-api-spec-docs/nrcrn-empl.json',
+  openApiJsonFileName: `${__dirname}/open-api-spec-docs/nrcrn-empl.json`,
   outputPath: './jest_output/empl/',
   typeFilterCallBack: nrsrxTypeFilterCallBack,
   valuePropertyTypeFilterCallBack: nrsrxValuePropertyTypeFilterCallBack,

--- a/src/app.string-array.spec.ts
+++ b/src/app.string-array.spec.ts
@@ -4,7 +4,7 @@ import { ValidateFiles } from './app.spec';
 import { IGeneratorOptions } from './models/generator-options';
 
 const fileEmployeeGenerationOptionsFactory = (): IGeneratorOptions => ({
-  openApiJsonFileName: '../src/open-api-spec-docs/string-array-test-oject.json',
+  openApiJsonFileName: `${__dirname}/open-api-spec-docs/string-array-test-oject.json`,
   outputPath: './jest_output/string-array/',
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ async function getOpenApiDocumentAsync(options: IGeneratorOptions): Promise<Open
     const response = await axios.get(options.openApiJsonUrl);
     apiDoc = response.data as OpenAPIObject;
   } else if (options.openApiJsonFileName) {
-    const response = fs.readFileSync(`${__dirname}/${options.openApiJsonFileName}`);
+    const response = fs.readFileSync(options.openApiJsonFileName);
     apiDoc = JSON.parse(response.toString()) as OpenAPIObject;
   } else {
     throw new Error(


### PR DESCRIPTION
This PR is a little fix that allows the openapiFilename to refer to files outside the script source directory (__dirname).